### PR TITLE
Configure Web App endpoint for score logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
     const POINTS_BAD = -50;
     const LEVEL_SIZE = 10;     // ítems aproximados por nivel
     const RECORDS_KEY = "records"; // almacenamiento de puntuaciones
+    const WEB_APP_URL = "https://script.google.com/macros/s/AKfycbxa1FR9jv1hyoe590Pt3bY760Oghl7Q8BCZ9w-wrmOJw6p7A4aJghdB7tczfiyVDbGEeg/exec";
 
     // Ítems del juego (editables)
     const ITEMS = [
@@ -263,6 +264,17 @@
           const records = JSON.parse(localStorage.getItem(RECORDS_KEY) || "[]");
           records.push({ nombre: nombreCompleto, puntos: score });
           localStorage.setItem(RECORDS_KEY, JSON.stringify(records));
+          fetch(WEB_APP_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              nombre: nombreCompleto,
+              puntos: score,
+              ok: stats.ok,
+              bad: stats.bad,
+              explicaciones: stats.explanations
+            })
+          }).catch(err=>console.error('Error enviando datos', err));
         }
       },100);
     }


### PR DESCRIPTION
## Summary
- configure `WEB_APP_URL` with deployed Apps Script endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8dbf66c83318f31ab77e36edaa8