### PR TITLE
Send scores to Google Sheet and expand recyclable items

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
   <meta name="description" content="Juego educativo de clasificación de residuos: orgánico, reciclable y no aprovechable." />
   <style>
     :root{
-      --bg:#ffffff;          /* fondo blanco */
+      --bg:#ffffff;          /* fondo blanco solicitado */
       --text:#111827;        /* texto principal gris oscuro */
       --muted:#6b7280;       /* texto secundario */
-      --card:#ffffff;        /* tarjetas claras */
+      --card:#f8fafc;        /* tarjetas claras */
       --border:#e5e7eb;      /* borde suave */
       --shadow:0 10px 30px rgba(0,0,0,.08);
       --radius:18px;
@@ -44,7 +44,7 @@
       position:sticky;top:0;z-index:5;
     }
     .title{font-weight:800;letter-spacing:.2px}
-    .stat{background:var(--card);border:1px solid var(--border);padding:8px 12px;border-radius:999px;font-size:14px}
+    .stat{background:#f3f4f6;border:1px solid var(--border);padding:8px 12px;border-radius:999px;font-size:14px}
     .wrap{padding:18px}
     .arena{display:grid;grid-template-columns:1fr;gap:18px}
     .itemCard{
@@ -80,7 +80,7 @@
     .bin[data-cat="Orgánico"]{--binColor:var(--bin-org)}
     .bin[data-cat="Reciclable"]{--binColor:var(--bin-rec)}
     .bin[data-cat="No aprovechable"]{--binColor:var(--bin-noap)}
-    .bin.hover{transform:translateY(-2px);border-color:var(--binColor);background:var(--card)}
+    .bin.hover{transform:translateY(-2px);border-color:var(--binColor);background:#f8fafc}
     .feedback{
       position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
       pointer-events:none;font-size:28px;font-weight:900;letter-spacing:.2px;
@@ -99,10 +99,10 @@
     .modalCard{width:min(560px,100%);background:#fff;border:1px solid var(--border);
                border-radius:18px;box-shadow:var(--shadow);padding:20px;text-align:center;color:var(--text)}
     .stars{font-size:28px;margin:8px 0 2px}
-    .explain{margin-top:10px;text-align:left;background:var(--card);border:1px solid var(--border);
+    .explain{margin-top:10px;text-align:left;background:#f8fafc;border:1px solid var(--border);
              border-radius:14px;padding:12px;max-height:220px;overflow:auto}
     .row{display:flex;gap:8px;flex-wrap:wrap;align-items:center;justify-content:center}
-    .tag{font-size:12px;background:var(--card);border:1px solid var(--border);padding:4px 8px;border-radius:999px;color:#1e3a8a}
+    .tag{font-size:12px;background:#eef2ff;border:1px solid #dbeafe;padding:4px 8px;border-radius:999px;color:#1e3a8a}
     @media (max-width:720px){
       .itemEmoji{font-size:56px}
       .itemName{font-size:20px}
@@ -173,25 +173,42 @@
     const POINTS_OK = 100;
     const POINTS_BAD = -50;
     const LEVEL_SIZE = 10;     // ítems aproximados por nivel
-    const RECORDS_KEY = "records"; // almacenamiento de puntuaciones
+    const WEB_APP_URL = "https://script.google.com/macros/s/AKfycbxa1FR9jv1hyoe590Pt3bY760Oghl7Q8BCZ9w-wrmOJw6p7A4aJghdB7tczfiyVDbGEeg/exec";
 
     // Ítems del juego (editables)
     const ITEMS = [
       {name:"Cáscara de plátano", emoji:"🍌", cat:"Orgánico", tip:"Restos de frutas y verduras son compostables."},
       {name:"Hojas secas", emoji:"🍂", cat:"Orgánico", tip:"Material ideal para compost."},
       {name:"Café molido usado", emoji:"☕️", cat:"Orgánico", tip:"Aporta nitrógeno al compost."},
+      {name:"Cáscara de huevo", emoji:"🥚", cat:"Orgánico", tip:"Se puede compostar (mejor triturada)."},
+      {name:"Restos de comida", emoji:"🍽️", cat:"Orgánico", tip:"Van al contenedor orgánico/compost."},
+      {name:"Cáscara de naranja", emoji:"🍊", cat:"Orgánico", tip:"Las cáscaras de cítricos también son compostables."},
+      {name:"Posos de té", emoji:"🍵", cat:"Orgánico", tip:"Tras usarlo, el té se convierte en un buen abono."},
+      {name:"Pan duro", emoji:"🥖", cat:"Orgánico", tip:"El pan viejo puede compostarse si no tiene moho."},
+      {name:"Ramas pequeñas", emoji:"🌿", cat:"Orgánico", tip:"Tritúralas para acelerar el compostaje."},
+      {name:"Yerba mate usada", emoji:"🧉", cat:"Orgánico", tip:"Aporta nutrientes al compost."},
+
       {name:"Botella plástica (PET)", emoji:"🥤", cat:"Reciclable", tip:"Enjuaga y aplasta para reciclar."},
       {name:"Lata de aluminio", emoji:"🥫", cat:"Reciclable", tip:"El aluminio es altamente reciclable."},
       {name:"Papel/Cartón limpio", emoji:"📄", cat:"Reciclable", tip:"Evita mezclarlo con comida o grasa."},
       {name:"Botella de vidrio", emoji:"🍾", cat:"Reciclable", tip:"El vidrio se recicla infinitas veces."},
+      {name:"Revista", emoji:"📚", cat:"Reciclable", tip:"Si está seca y limpia, se recicla."},
+      {name:"Caja de cartón", emoji:"📦", cat:"Reciclable", tip:"Dobla y mantén seca para reciclar."},
+      {name:"Periódico", emoji:"📰", cat:"Reciclable", tip:"El papel periódico seco se recicla."},
+      {name:"Bolsa de papel", emoji:"🛍️", cat:"Reciclable", tip:"Reutiliza y recicla las bolsas de papel."},
+      {name:"Frasco de vidrio", emoji:"🧴", cat:"Reciclable", tip:"Retira la tapa y limpia antes de reciclar."},
+      {name:"Bote de aerosol vacío", emoji:"🧪", cat:"Reciclable", tip:"Asegúrate de que esté completamente vacío."},
+      {name:"Lata de conservas", emoji:"🥫", cat:"Reciclable", tip:"Enjuaga para facilitar el reciclaje."},
+
       {name:"Servilleta sucia", emoji:"🧻", cat:"No aprovechable", tip:"Contaminada: va a no aprovechable."},
       {name:"Paquete de snacks", emoji:"🍟", cat:"No aprovechable", tip:"Multicapa difícil de reciclar."},
       {name:"Colilla de cigarrillo", emoji:"🚬", cat:"No aprovechable", tip:"Desecho contaminante, nunca al piso."},
       {name:"Pañal desechable", emoji:"🍼", cat:"No aprovechable", tip:"Residuos sanitarios → no aprovechable."},
-      {name:"Cáscara de huevo", emoji:"🥚", cat:"Orgánico", tip:"Se puede compostar (mejor triturada)."},
-      {name:"Revista", emoji:"📚", cat:"Reciclable", tip:"Si está seca y limpia, se recicla."},
-      {name:"Caja de cartón", emoji:"📦", cat:"Reciclable", tip:"Dobla y mantén seca para reciclar."},
-      {name:"Restos de comida", emoji:"🍽️", cat:"Orgánico", tip:"Van al contenedor orgánico/compost."}
+      {name:"Envase de icopor", emoji:"🍱", cat:"No aprovechable", tip:"El icopor no se recicla, deposítalo en no aprovechable."},
+      {name:"Chicle", emoji:"🍬", cat:"No aprovechable", tip:"No es biodegradable; deséchalo en no aprovechable."},
+      {name:"Cepillo de dientes usado", emoji:"🪥", cat:"No aprovechable", tip:"Contiene mezclas de materiales difíciles de reciclar."},
+      {name:"CD o DVD roto", emoji:"💿", cat:"No aprovechable", tip:"La mezcla de materiales impide su reciclaje."},
+      {name:"Esponja de cocina gastada", emoji:"🧽", cat:"No aprovechable", tip:"Acumula bacterias y no es reciclable."}
     ];
 
     // =========================
@@ -256,15 +273,18 @@
         p.textContent = "• " + txt;
         box.appendChild(p);
       });
+      fetch(WEB_APP_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nombre: 'Anónimo',
+          puntos: score,
+          ok: stats.ok,
+          bad: stats.bad,
+          explicaciones: stats.explanations
+        })
+      }).catch(err => console.error('No se pudo enviar al registro', err));
       $("#modal").classList.add("show");
-      setTimeout(()=>{
-        const nombreCompleto = prompt("Ingresa tu nombre completo:");
-        if(nombreCompleto){
-          const records = JSON.parse(localStorage.getItem(RECORDS_KEY) || "[]");
-          records.push({ nombre: nombreCompleto, puntos: score });
-          localStorage.setItem(RECORDS_KEY, JSON.stringify(records));
-        }
-      },100);
     }
     function startTimer(){
       clearInterval(timer);


### PR DESCRIPTION
## Summary
- Use provided Google Apps Script endpoint to record scores and stats
- Expand the catalog of recyclable, organic and non-recyclable items to enrich gameplay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8dbf66c83318f31ab77e36edaa8